### PR TITLE
rfc search: Use grep -R option rather than shell globbing

### DIFF
--- a/rfc
+++ b/rfc
@@ -113,7 +113,7 @@ __rfc() {
             echo 'Usage: rfc search "<pattern>"'
             return $UNRECOGNIZED_CMD;
         fi
-        grep -Is --exclude _404s $@ $rfc_dir/* | sed "s%$rfc_dir/%RFC %"
+        grep -RIs --exclude _404s $@ "$rfc_dir" | sed "s%$rfc_dir/%RFC %"
         return 0
     }
 


### PR DESCRIPTION
Hello! I enjoy using this project and have recommended it to many others. When installing it on a computer with a low bash `ARG_MAX`, I noticed that the search functionality was breaking with "Argument list too long". To reproduce this, install rfc on a machine with a low ARG_MAX (my test machine was 262144), then:

```
$ rfc sync all
$ rfc search dns
/home/delucks/bin/rfc: line 116: /usr/bin/grep: Argument list too long
```

This PR changes `rfc` to use `grep -R` across the entire RFC cache directory rather than doing a stock `grep` against every element of the RFC directory using shell globbing. This should be more robust across embedded devices and other machines with a small amount of available memory. In my manual tests, all the output of the tool has been the same before & after this change. All tests pass as well:

```
$ ./test/tests.sh
all 5 rfc tests passed in 0.947s.
```