### PR TITLE
Update remote URL

### DIFF
--- a/rfc
+++ b/rfc
@@ -24,7 +24,7 @@ __rfc() {
     local NO_CURL_WGET=4
 
     # URLs
-    local RFC_REMOTE_URL='https://raw.github.com/bfontaine/rfc/master/rfc'
+    local RFC_REMOTE_URL='https://raw.githubusercontent.com/bfontaine/rfc/master/rfc'
     local REPO_HOME='https://github.com/bfontaine/rfc'
     local ISSUES_URL='https://github.com/bfontaine/rfc/issues'
 


### PR DESCRIPTION
The old/current remote URL is a redirect. This PR updates it to use the new URL. This is needed when using curl since it does not follow redirects by default.

Alternatively we could enable redirects by adding the `-L` flag to curl, as in d026a41a4dbdab0a8a3aab3d73aa6e8825c93c85