### PR TITLE
feat: show titles when listing rfcs

### DIFF
--- a/rfc
+++ b/rfc
@@ -132,7 +132,15 @@ __rfc() {
 
     # rfc list
     list() {
-        \ls -1 "$rfc_dir" | grep '^[0-9]\{1,\}$' | sort -n | sed 's/^/RFC /'
+        find "$rfc_dir" -maxdepth 1 -type f -regex '.*/[^_/]*' -print | sort | xargs -I {} awk '
+          /./ && !prev    { i++ }
+          /./ && i == 2   { title = title " " $0 }
+          /./ && i > 2    { n = split(FILENAME, a, "/")
+                            gsub(" +", " ", title)
+                            gsub("^ *", "", title)
+                            print "RFC " a[n] ": " title
+                            exit }
+                          { prev = $0 }' {}
     }
 
     # rfc search <pattern>

--- a/rfc
+++ b/rfc
@@ -28,9 +28,9 @@ __rfc() {
     local REPO_HOME='https://github.com/bfontaine/rfc'
     local ISSUES_URL='https://github.com/bfontaine/rfc/issues'
 
-    local RFCS_TGZ_BASEURL='https://www.rfc-editor.org/in-notes/tar/'
-    local RFCS_BASEURL='https://www.rfc-editor.org/rfc/'
-    local DRAFTS_BASEURL='https://www.ietf.org/id/'
+    local RFCS_TGZ_BASEURL='https://www.rfc-editor.org/in-notes/tar'
+    local RFCS_BASEURL='https://www.rfc-editor.org/rfc'
+    local DRAFTS_BASEURL='https://www.ietf.org/id'
 
     if [ -n "$RFC_DIR" ]; then
       rfc_dir="$RFC_DIR"
@@ -181,7 +181,7 @@ __rfc() {
         fi
 
         mkdir -p "$rfc_dir/_tmp"
-        if fetch_url "$RFCS_TGZ_BASEURL$name" "$rfc_dir/_tmp/$name"; then
+        if fetch_url "$RFCS_TGZ_BASEURL/$name" "$rfc_dir/_tmp/$name"; then
           :
         else
           exit $NETWORK_ERROR

--- a/rfc.bash
+++ b/rfc.bash
@@ -1,0 +1,9 @@
+__punch_complete() {
+  local cur=$2
+  if [ $COMP_CWORD -eq 1 ]; then
+    COMPREPLY=( $(compgen -W "--version --help search list sync clear $(rfc list | cut -d ':' -f 1 | cut -d ' ' -f 2)" -- $cur) )
+  elif [ $COMP_CWORD -eq 2 ] && [ "${COMP_WORDS[1]}" == "sync" ]; then
+    COMPREPLY=( $(compgen -W "week month all" -- $cur) )
+  fi
+} &&
+complete -F __punch_complete rfc

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -45,7 +45,7 @@ __rfc_tests() {
     assert_raises "[ -f '$RFC_DIR/42' ]"
     assert_raises "[ ! -f '$XDG_CACHE_HOME/RFCs/42' ]"
 
-    assert "$rfc list" 'RFC 42'
+    assert "$rfc list" 'RFC 42: Message Data Types'
 
     ## == teardown == ##
 


### PR DESCRIPTION
The main part of the PR is to show the RFC titles when running `rfc list`.

This PR comes with a minor fix that removes double slashes in URLs.