### PR TITLE
further improvements to `rfc list`

### DIFF
--- a/rfc
+++ b/rfc
@@ -132,15 +132,23 @@ __rfc() {
 
     # rfc list
     list() {
-        find "$rfc_dir" -maxdepth 1 -type f -regex '.*/[^_/]*' -print | sort | xargs -I {} awk '
+      (
+        cd "$rfc_dir"
+        \ls -1 | grep -v '^_' | sort -n | xargs awk '
           /./ && !prev    { i++ }
           /./ && i == 2   { title = title " " $0 }
           /./ && i > 2    { n = split(FILENAME, a, "/")
                             gsub(" +", " ", title)
                             gsub("^ *", "", title)
-                            print "RFC " a[n] ": " title
-                            exit }
-                          { prev = $0 }' {}
+                            if (int(a[n]))
+                              printf "RFC %5d: %s\n", a[n], title
+                            else
+                              printf "RFC %s: %s\n", a[n], title
+                            i = 0
+                            title = ""
+                            nextfile }
+                          { prev = $0 }'
+        )
     }
 
     # rfc search <pattern>

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -45,7 +45,7 @@ __rfc_tests() {
     assert_raises "[ -f '$RFC_DIR/42' ]"
     assert_raises "[ ! -f '$XDG_CACHE_HOME/RFCs/42' ]"
 
-    assert "$rfc list" 'RFC 42: Message Data Types'
+    assert "$rfc list" 'RFC    42: Message Data Types'
 
     ## == teardown == ##
 


### PR DESCRIPTION
- numeric sort cached RFCs (sorry for breaking that earlier)
- right align numeric RFCs
- also list drafts
- use a single `awk` call instead one-per-file
